### PR TITLE
Make naming GOV.UK Content API consistent

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -2,9 +2,9 @@
 title: GOV.UK Content API Documentation
 ---
 
-# About the GOV.UK Content API
+# About GOV.UK Content API
 
-The GOV.UK Content API makes it easy to access the data used to render content
+GOV.UK Content API makes it easy to access the data used to render content
 on [https://www.gov.uk](https://www.gov.uk). For any page hosted on www.gov.uk
 you can lookup the [path](#quick-start) to access the content component and
 associated metadata for a page.
@@ -18,23 +18,23 @@ you wish to access historic content this can currently be done through the
 [National Archives][]. Historic data may be made available through future
 developments to this API.
 
-The API is accessed via [HTTP][] and returns data in a [JSON][] format. The
-[reference documentation](reference.html) provides a thorough overview of the
-endpoints and the response format.
+GOV.UK Content API is accessed via [HTTP][] and returns data in a [JSON][]
+format. The [reference documentation](reference.html) provides a thorough
+overview of the endpoints and the response format.
 
 ## Quick start
 
-You can use this API to lookup the data that is used to render content on
-GOV.UK.
+You can use GOV.UK Content API to lookup the data that is used to render
+content on GOV.UK.
 
 To get started:
 
  1. Pick a page on GOV.UK eg. [https://www.gov.uk/take-pet-abroad](https://www.gov.uk/take-pet-abroad)
  2. Make a note of the path eg. `/take-pet-abroad`
  3. Using a tool such as [curl](https://curl.haxx.se/),
-    [Postman](https://www.getpostman.com/) or your web browser make a GET
+    [Postman](https://www.getpostman.com/) or your web browser, make a GET
     request to [`https://www.gov.uk/api/content/take-pet-abroad`](https://www.gov.uk/api/content/take-pet-abroad)
- 4. You’ll receive a JSON response, the fields for this are
+ 4. You’ll receive a JSON response and the fields for this are
     explained in the [reference documentation](reference.html)
 
 For example, using [curl](https://curl.haxx.se/) command line utility and the
@@ -46,10 +46,11 @@ curl https://www.gov.uk/api/content/take-pet-abroad | jq
 
 ## Support
 
-Content API is currently in a [beta](https://www.gov.uk/help/beta) phase and may
-be subject to changes and improvements.
+GOV.UK Content API is currently in a [beta](https://www.gov.uk/help/beta)
+phase and may be subject to changes and improvements.
 
-If you experience any issues or have questions regarding the Content API please:
+If you experience any issues or have questions regarding GOV.UK Content API
+please:
 
 - **If you are a government department:** Raise a ticket with [GOV.UK Support][]
 - **Otherwise:** [Contact GOV.UK][] with your query
@@ -58,40 +59,40 @@ If you experience any issues or have questions regarding the Content API please:
 
 ### Reporting vulnerabilities
 
-If you believe there is a security issue with the GOV.UK Content API, please
+If you believe there is a security issue with GOV.UK Content API, please
 [contact us immediately](#support).
 
 Please don’t disclose the suspected breach publicly until it has been fixed.
 
 ### HTTPS
 
-GOV.UK Content API follows government HTTPS security guidelines. The Hypertext
-Transfer Protocol Secure (HTTPS), which involves the Transport Layer Security
-(TLS) protocol is used by the platform to provide secure connections.
+GOV.UK Content API follows government HTTPS security guidelines. The
+Hypertext Transfer Protocol Secure (HTTPS), which involves the Transport Layer
+Security (TLS) protocol is used by the platform to provide secure connections.
 
 ### Security patches
 
 We treat security vulnerabilities in the platform and library code in the GOV.UK
-Content API as highest priority. The API codebase will be updated as soon as
+Content API as our highest priority. The codebase will be updated as soon as
 possible when vulnerabilities are discovered or reported.
 
-We frequently upgrade the framework and library code in the GOV.UK Content API
-to latest versions for security and feature enhancements.
+We frequently upgrade the framework and library code in GOV.UK Content API
+to the latest versions for security and feature enhancements.
 
 ## Rate limiting and record limits
 
 There is a maximum limit of 10 requests per second per client. If you exceed
-this, your request won't be processed until the limit is no longer exceeded
+this your request won't be processed until the limit is no longer exceeded
 and you may see timeout errors.
 
-We think this should be sufficient for all users of the API but if you believe
-you need the limit increasing you can [contact support](#support).
+We think this should be sufficient for all users of GOV.UK Content API but
+if you believe you need the limit increasing you can [contact support](#support).
 
 ## Versioning
 
-This API is currently beta software and may be subject to changes and
-improvements as we learn from usage. We intend to introduce a versioning
-distinction to the API before we complete the beta phase.
+GOV.UK Content API is currently beta software and may be subject to changes
+and improvements as we learn from usage. We intend to introduce a versioning
+distinction to this API before we complete the beta phase.
 
 [National Archives]: http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/
 [HTTP]: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol


### PR DESCRIPTION
We've decided to refer to this API as the GOV.UK Content API and this updates
all references to it to be consistent with this name.

https://trello.com/c/dKWWoydb/1104-consistent-naming-of-govuk-content-api-in-documentation