### PR TITLE
Remove WIP banner - restore in-page navigation

### DIFF
--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -48,10 +48,6 @@
 
         <div class="app-pane__content toc-open-disabled">
           <main id="content" class="technical-documentation" data-module="anchored-headings">
-            <div class="wip-banner">
-              This API is work in progress and not yet ready for use.
-            </div>
-
             <%= yield %>
           </main>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -2,7 +2,7 @@
 wrap_layout :core do
   html = yield
 
-  # content_for(:toc_module, "in-page-navigation")
+  content_for(:toc_module, "in-page-navigation")
 
   content_for :sidebar do
     table_of_contents(


### PR DESCRIPTION
The work in progress banner is a big factor in breaking the in-page
navigation. The in-page navigation module fixes problems with the back
button - and, of course, introduces a couple of new problems.