### PR TITLE
Add phase banner

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,7 +2,19 @@
 title: GOV.UK Content API Documentation
 ---
 
-# About GOV.UK Content API
+# GOV.UK Content API
+
+<div class="phase-tag">
+  <p>
+    <strong class="phase-banner"><%= config[:tech_docs][:phase] %></strong>
+    <span>
+      This is a trial service — your
+      <a href="http://www.smartsurvey.co.uk/s/GPYGP">feedback</a>
+      will help us to improve it. <a href="#beta-software">Find out what
+      this means</a>.
+    </span>
+  </p>
+</div>
 
 GOV.UK Content API makes it easy to access the data used to render content
 on [https://www.gov.uk](GOV.UK). For any page hosted on GOV.UK you can use

--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -48,6 +48,16 @@
 
         <div class="app-pane__content toc-open-disabled">
           <main id="content" class="technical-documentation" data-module="anchored-headings">
+            <div class="phase-tag">
+              <p>
+                <strong class="phase-banner"><%= config[:tech_docs][:phase] %></strong>
+                <span>
+                  This is a trial service — your
+                  <a href="http://www.smartsurvey.co.uk/s/GPYGP">feedback</a>
+                  will help us to improve it.
+                </span>
+              </p>
+            </div>
             <%= yield %>
           </main>
 

--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -23,7 +23,7 @@
   <body>
     <div class="app-pane">
       <div class="app-pane__header toc-open-disabled">
-        <a href="#content" class="skip-link">Skip to main content</a>
+        <a href="#main-content" class="skip-link">Skip to main content</a>
 
         <%= partial 'layouts/header' %>
       </div>
@@ -47,17 +47,7 @@
         <% end %>
 
         <div class="app-pane__content toc-open-disabled">
-          <main id="content" class="technical-documentation" data-module="anchored-headings">
-            <div class="phase-tag">
-              <p>
-                <strong class="phase-banner"><%= config[:tech_docs][:phase] %></strong>
-                <span>
-                  This is a trial service — your
-                  <a href="http://www.smartsurvey.co.uk/s/GPYGP">feedback</a>
-                  will help us to improve it.
-                </span>
-              </p>
-            </div>
+          <main id="main-content" class="technical-documentation" data-module="anchored-headings">
             <%= yield %>
           </main>
 

--- a/source/stylesheets/govuk_frontend_toolkit/colours/_palette.scss
+++ b/source/stylesheets/govuk_frontend_toolkit/colours/_palette.scss
@@ -70,7 +70,7 @@ $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
 $discovery-colour: $fuschia;      // Discovery badges and banners
 $alpha-colour: $pink;             // Alpha badges and banners
-$beta-colour: $orange;            // Beta badges and banners
+$beta-colour: $govuk-blue;        // Beta badges and banners
 $live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $red;              // Error text and border colour

--- a/source/stylesheets/modules/_phase-banner.scss
+++ b/source/stylesheets/modules/_phase-banner.scss
@@ -16,7 +16,7 @@
   vertical-align: middle;
 
   @include screen {
-    //background: $govuk-blue;
+    // background: $beta-colour;
     background: red;
     color: $white;
   }


### PR DESCRIPTION
For [Trello](https://trello.com/c/XPAWbL4K/1081-05-add-beta-banner-to-the-api-documentation)

* We add a phase banner with a link to a feedback survey in preparation for changing the phase for GOV.UK Content API to beta.

* We also change the default colour for Beta banners to `govuk-blue` as per [`govuk_frontend_toolkit`](https://github.com/alphagov/govuk_frontend_toolkit/blob/89168934d1455754f455c398ba5c350a484d9a2a/stylesheets/colours/_palette.scss).  

* The textual inspiration for this banner comes from https://beta.companieshouse.gov.uk/.

**Previous**:

![screen shot 2017-09-18 at 14 01 41](https://user-images.githubusercontent.com/13434452/30546054-6d43fbcc-9c83-11e7-8466-80306aab9400.png)

**New**: 

![screen shot 2017-09-18 at 16 49 17](https://user-images.githubusercontent.com/13434452/30551110-5b4bb064-9c91-11e7-8210-f33657aedf0e.png)
