### PR TITLE
Change phase to beta

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ host: https://content-api.publishing.service.gov.uk
 show_govuk_logo: true
 service_name: Content API
 service_link: /
-phase: Work In Progress
+phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:

--- a/source/stylesheets/modules/_phase-banner.scss
+++ b/source/stylesheets/modules/_phase-banner.scss
@@ -16,8 +16,8 @@
   vertical-align: middle;
 
   @include screen {
-    // background: $beta-colour;
-    background: red;
+    background: $beta-colour;
+    // background: red;
     color: $white;
   }
 }


### PR DESCRIPTION
For [Trello](https://trello.com/c/XPAWbL4K/1081-05-add-beta-banner-to-the-api-documentation)

GOV.UK Content API is now in beta! 🎉  So we change the wording and colour of the
phase banner to reflect this.