### PR TITLE
Link to GOV.UK browser extension

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -76,6 +76,8 @@ For example, using the curl command line utility tool:
 curl https://www.gov.uk/api/content/take-pet-abroad
 ```
 
+Or, you can use the [govuk-browser-extension](https://github.com/alphagov/govuk-browser-extension). Note that this is intended for internal use.
+
 ## Beta software
 
 GOV.UK Content API is currently beta software and may be subject to changes


### PR DESCRIPTION
Most GOV.UK devs use the browser extension for quickly querying the content API.