### PR TITLE
Modernize content

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -104,8 +104,9 @@ Usage of GOV.UK Content API does not require authentication.
 
 ### Reporting vulnerabilities
 
-If you believe there is a security issue with GOV.UK Content API, please
-[contact us immediately](#support).
+If you believe there is a security issue with GOV.UK Content API, read our [security
+policy](https://github.com/alphagov/.github/blob/master/SECURITY.md)
+and [contact us immediately](https://github.com/alphagov/.github/blob/master/SECURITY.md#reporting-a-vulnerability).
 
 Please don’t disclose the suspected breach publicly until it has been fixed.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -22,8 +22,8 @@ For any page hosted on GOV.UK you can use the [path](#quick-start) to access
 the content and associated metadata for a page.
 
 GOV.UK Content API is accessed via [HTTP][] and returns data in a [JSON][]
-format. The [reference documentation](reference.html) provides a thorough
-overview of the endpoints and the response format.
+format. The [reference documentation](reference.html) details the
+endpoints and the response format.
 
 ## What you can do with this API
 
@@ -51,14 +51,13 @@ may still be being migrated to utilise this API and these could appear
 as placeholder documents without any content or as redirections to a
 catch-all content item that represents a group of unmigrated content.
 
-This API provides access to content that is currently hosted on GOV.UK. If
-you wish to access historic content this can currently be done through the
-[National Archives][].
+If you wish to access historic content this can currently be done
+through the [National Archives][].
 
 ## Quick start
 
-You can use GOV.UK Content API to lookup the data that is used to render
-content on GOV.UK.
+You can use the GOV.UK Content API to look up the data that is used to
+render content on GOV.UK.
 
 To get started:
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -89,12 +89,6 @@ We will communicate those via our [mailing list](#keep-informed).
 If you would like to share your feedback about GOV.UK Content API you can do so
 via [this survey](http://www.smartsurvey.co.uk/s/GPYGP).
 
-## Keep informed
-
-Join the [GOV.UK Content API mailing list][google-group] to be notified of
-announcements regarding this API. We will use this channel to communicate
-any breaking changes or updates to the support status of this API.
-
 ## Authentication
 
 Usage of GOV.UK Content API does not require authentication.
@@ -145,7 +139,6 @@ please:
 - **Otherwise:** [Contact GOV.UK][] with your query
 
 
-[google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/contentapi
 [National Archives]: http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/
 [HTTP]: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
 [JSON]: https://en.wikipedia.org/wiki/JSON


### PR DESCRIPTION
- Remove 'keep informed' section as the Google Group no longer exists.
- Fix a load of style complaints as reviewed by tech writers in 2017!
- Update 'reporting vulnerabilities' section to link to the new security
  policy and disclosure instructions from `alphagov/.github`.