### PR TITLE
Remove link to keep informed

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -84,7 +84,6 @@ and improvements as we learn from usage.
 
 This means that you may use this software and build applications that utilise
 it. However as we learn from feedback we may make changes to the software.
-We will communicate those via our [mailing list](#keep-informed).
 
 If you would like to share your feedback about GOV.UK Content API you can do so
 via [this survey](http://www.smartsurvey.co.uk/s/GPYGP).


### PR DESCRIPTION
The section was removed in https://github.com/alphagov/govuk-content-api-docs/pull/48.

[Trello Card](https://trello.com/c/9zYixzLx/2102-2-fix-accessibility-issues-in-content-api-docs)