### PR TITLE
Fix broken link

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -143,5 +143,5 @@ please:
 [National Archives]: http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/
 [HTTP]: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
 [JSON]: https://en.wikipedia.org/wiki/JSON
-[GOV.UK Support]: https://support.publishing.service.gov.uk
+[Raise a ticket with GOV.UK Support]: https://support.publishing.service.gov.uk
 [Contact GOV.UK]: https://www.gov.uk/contact/govuk


### PR DESCRIPTION
The link text was changed in 208548d6bc80d704bc8dcfee27d8ae3a51c70036 which lead to the link being broken.