### PR TITLE
Ignore vulnerabilities in Widdershins dependency

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+version: v1.5.0
+ignore:
+  'SNYK-JS-ANSIREGEX-1583908':
+  - '* > ansi-regex@2.1.1':
+    reason: 'No fix available, only used at buildtime'
+  'SNYK-JS-AJV-584908':
+  - '* > ajv@5.5.2':
+    reason: 'No fix available, only used at buildtime'


### PR DESCRIPTION
We're pinned to a 7 year old version of this dependency and it's not feasible to upgrade. We only use it at build-time anyway.