### PR TITLE
Remove broken links

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -10,9 +10,6 @@ title: About - GOV.UK Content API
       <%= config[:tech_docs][:phase] %>
     </strong>
     <span class="govuk-phase-banner__text">
-      This is a trial service — your
-      <a class="govuk-link" href="http://www.smartsurvey.co.uk/s/GPYGP">feedback</a>
-      will help us to improve it.
       <a class="govuk-link" href="#beta-software">Find out what this means</a>.
     </span>
   </p>
@@ -87,9 +84,6 @@ and improvements as we learn from usage.
 
 This means that you may use this software and build applications that utilise
 it. However as we learn from feedback we may make changes to the software.
-
-Please use our survey if you would like to [share your feedback about GOV.UK
-Content API](http://www.smartsurvey.co.uk/s/GPYGP).
 
 ## Authentication
 


### PR DESCRIPTION
We are linking to a survey that no longer exists. Removing these links as there is currently no way of using providing feedback on the service through this route.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
