### PR TITLE
Update the GTM container ID [WHIT-3365]

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -27,4 +27,4 @@ prevent_indexing: false
 api_path: https://raw.githubusercontent.com/alphagov/content-store/refs/heads/main/openapi.yaml
 
 # Track usage
-ga4_gtm_tracking_id: GTM-TB4X2Z34
+ga4_gtm_tracking_id: GTM-5CPD828V


### PR DESCRIPTION
## What

Update the GTM container ID

## Why

Request from PAs

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
