### PR TITLE
Bump ruby/setup-ruby from 1.314.0 to 1.316.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps: 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       - name: Install dependencies
         run: |
           gem install bundler


### PR DESCRIPTION
Duplicate of #246 since the Brakeman scan isn't completing there
Closes #246

---

Bumps [ruby/setup-ruby](https://github.com/ruby/setup-ruby) from 1.314.0 to 1.316.0.
- [Release notes](https://github.com/ruby/setup-ruby/releases)
- [Changelog](https://github.com/ruby/setup-ruby/blob/master/release.rb)
- [Commits](https://github.com/ruby/setup-ruby/compare/9eb537ca036ebaed86729dcb9309076e4c5c3b74...d45b1a4e94b71acab930e56e79c6aa188764e7f9)

---
updated-dependencies:
- dependency-name: ruby/setup-ruby dependency-version: 1.316.0 dependency-type: direct:production update-type: version-update:semver-minor ...

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
