### PR TITLE
[PP-7834] Add Brakeman CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,11 @@ jobs:
   lint-ruby:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
+      actions: read

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem "govuk_tech_docs"
 gem "middleman-gh-pages", "~> 0.4.1"
 
 group :development, :test do
+  gem "brakeman"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
       execjs (~> 2)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    brakeman (8.0.5)
+      racc
     chronic (0.10.2)
     chunky_png (1.4.0)
     coffee-script (2.4.1)
@@ -270,6 +272,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman
   govuk_tech_docs
   middleman-gh-pages (~> 0.4.1)
   rubocop-govuk


### PR DESCRIPTION
https://github.com/alphagov/govuk-infrastructure/commit/34172aa0c9a920d54266bb59b638ca0e76bb1808 changed the required checks for this repo to include the standard GOV.UK set for Rails, including Brakeman. However, we didn't include a Brakeman job in any of our GitHub workflows. This blocked PRs from being merged because a required status check would never have an associated job run. This therefore adds Brakeman using the shared workflow from govuk-infrastructure

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
